### PR TITLE
Upgrade eql to 0.2.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {deps,
  [
   {envloader, {git, "https://github.com/nuex/envloader.git", {branch, "master"}}},
-  {eql, {git, "git://github.com/artemeff/eql.git", {tag, "0.1.0"}}},
+  {eql, "0.2.0"},
   getopt,
   epgsql
  ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,13 +4,11 @@
        {ref,"27a97e04f35c554995467b9236d8ae0188d468c7"}},
   0},
  {<<"epgsql">>,{pkg,<<"epgsql">>,<<"4.3.0">>},0},
- {<<"eql">>,
-  {git,"git://github.com/artemeff/eql.git",
-       {ref,"a6727a3f878bfdd06648b7a886cbd2c0630db172"}},
-  0},
+ {<<"eql">>,{pkg,<<"eql">>,<<"0.2.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},0}]}.
 [
 {pkg_hash,[
  {<<"epgsql">>, <<"26D9CF04D74773D1DC4DA24AD39E926B34E107232591FE1866EFDFBC0A098396">>},
+ {<<"eql">>, <<"598ABC19A1CF6AFB8EF89FFEA869F43BAEBB1CEC3260DD5065112FEE7D8CE3E2">>},
  {<<"getopt">>, <<"C73A9FA687B217F2FF79F68A3B637711BB1936E712B521D8CE466B29CBF7808A">>}]}
 ].

--- a/src/psql_migration.erl
+++ b/src/psql_migration.erl
@@ -248,7 +248,7 @@ apply_migrations(Type, Migrations, Conn) ->
     lists:reverse(Results).
 
 apply_migration(Type, {Version, Migration}, Conn) ->
-    Query = eql:get_query(Type, Migration),
+    {ok, Query} = eql:get_query(Type, Migration),
     case if_ok(?DRIVER:squery(Conn, Query)) of
         ok ->
             record_migration(Type, Conn, Version),


### PR DESCRIPTION
Hi,

When I try to use psql-migration with the latest eql (I already have 0.2.0 in my project), migration fails with the error below:
```
** Reason for termination ==
** {badarg,[{erlang,iolist_size,
                    [[{ok,<<"CREATE TABLE users (   id BIGSERIAL PRIMARY KEY,   email TEXT NOT NULL
```
It seems eql:get_query returns a tuple in the newest version instead of raw query.  This PR should fix the error.