### PR TITLE
Allow more ssl parameters and support empty value

### DIFF
--- a/src/psql_migration.erl
+++ b/src/psql_migration.erl
@@ -198,8 +198,9 @@ connection_opts(_Args, {url, DatabaseUrl}) ->
                         [] -> {ok, ConnectionOpts};
                         QueryList ->
                             case proplists:get_value("ssl", QueryList) of
-                                "true" -> {ok, maps:put(ssl, true, ConnectionOpts)};
-                                _ -> {ok, ConnectionOpts}
+                                undefined -> {ok, ConnectionOpts};
+                                [] -> {ok, maps:put(ssl, true, ConnectionOpts)};
+                                Value -> {ok, maps:put(ssl, list_to_atom(Value), ConnectionOpts)}
                             end
                     end
             end


### PR DESCRIPTION
This is more robust for ssl values and is more aligned with the url spec. @madninja 

Addresses some of what we talked about in #4 