### PR TITLE
Add .env.template and strip newline characters from database URLs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://user:password@hostname/database

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ _build
 *.iml
 rebar3.crashdump
 .DS_Store
-.env*
+*.env
 .tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ _build
 *.iml
 rebar3.crashdump
 .DS_Store
-*.env
+.env*
+!.env.template
 .tool-versions

--- a/src/psql_migration.erl
+++ b/src/psql_migration.erl
@@ -193,7 +193,7 @@ connection_opts(Args, {env, URLName}) ->
         DatabaseUrl -> connection_opts(Args, {url, DatabaseUrl})
     end;
 connection_opts(_Args, {url, DatabaseUrl}) ->
-    case uri_string:parse(re:replace(DatabaseUrl, "\\r|\\n", "", [global,{return,list}])) of
+    case uri_string:parse(string:trim(DatabaseUrl)) of
         {error, Error, Term} ->
             {error, {Error, Term}};
         Map = #{userinfo := UserPass, host := Host, path := Path} ->

--- a/src/psql_migration.erl
+++ b/src/psql_migration.erl
@@ -193,7 +193,7 @@ connection_opts(Args, {env, URLName}) ->
         DatabaseUrl -> connection_opts(Args, {url, DatabaseUrl})
     end;
 connection_opts(_Args, {url, DatabaseUrl}) ->
-    case uri_string:parse(DatabaseUrl) of
+    case uri_string:parse(re:replace(DatabaseUrl, "\\r|\\n", "", [global,{return,list}])) of
         {error, Error, Term} ->
             {error, {Error, Term}};
         Map = #{userinfo := UserPass, host := Host, path := Path} ->


### PR DESCRIPTION
I think it would be convenient to include a .env.template file just like there is in `blockchain-http`. This way users can simply input their database details without having to figure out the correct URI format on their own.

Summary of changes:
- Add .env.template
- Strip newline characters from database URLs